### PR TITLE
issue #26988 - Minor tweak to allow comments in package.xml file

### DIFF
--- a/common/package.cpp
+++ b/common/package.cpp
@@ -150,6 +150,9 @@ Package::Package(const QDomElement & elem, QStringList &msgList,
       _finalscripts.append(new FinalScript(elemThis, msgList, fatalList));
     else if(elemThis.tagName() == "initscript")
       _initscripts.append(new InitScript(elemThis, msgList, fatalList));
+    else if(elemThis.tagName() == "comment")
+      // Package Comment - Do nothing
+      bool comments = true;  
     else if (! reportedErrorTags.contains(elemThis.tagName()))
     {
       if (handler)


### PR DESCRIPTION
Allows the <comment> tag to be included in the package.xml for commenting/documenting larger custom packages.  

Does nothing with the comment, but suppresses warning about unknown element.