### PR TITLE
Issue #26988: Allow XML comments in package.xml file

### DIFF
--- a/common/package.cpp
+++ b/common/package.cpp
@@ -150,8 +150,8 @@ Package::Package(const QDomElement & elem, QStringList &msgList,
       _finalscripts.append(new FinalScript(elemThis, msgList, fatalList));
     else if(elemThis.tagName() == "initscript")
       _initscripts.append(new InitScript(elemThis, msgList, fatalList));
-    else if(elemThis.tagName() == "comment")
-      // Package Comment - Do nothing
+    else if(elemThis.tagName() == "comment" || elemThis.tagName() == "")
+      // Package <comment> tag or XML comment - Do nothing
       bool comments = true;  
     else if (! reportedErrorTags.contains(elemThis.tagName()))
     {

--- a/common/package.cpp
+++ b/common/package.cpp
@@ -150,7 +150,7 @@ Package::Package(const QDomElement & elem, QStringList &msgList,
       _finalscripts.append(new FinalScript(elemThis, msgList, fatalList));
     else if(elemThis.tagName() == "initscript")
       _initscripts.append(new InitScript(elemThis, msgList, fatalList));
-    else if(elemThis.tagName() == "comment" || elemThis.tagName() == "")
+    else if(elemThis.tagName() == "comment" || nList.item(n).isComment())
       // Package <comment> tag or XML comment - Do nothing
       bool comments = true;  
     else if (! reportedErrorTags.contains(elemThis.tagName()))


### PR DESCRIPTION
Additional tweak to allow standard XML comments in the package.xml file without triggering warnings or error messages