### PR TITLE
disable the pkg table from the list, not pkgpriv repeatedly

### DIFF
--- a/loader/loaderwindow.cpp
+++ b/loader/loaderwindow.cpp
@@ -1051,7 +1051,7 @@ int LoaderWindowPrivate::disableTriggers()
     {
       schema = i->schema();
       if (schema.isEmpty() && ! _p->_package->system() && ! triggers.contains("pkg" + key))
-        triggers.append("pkgpriv");
+        triggers.append("pkg" + key);
       else if (! schema.isEmpty() && "public" != schema && ! triggers.contains(schema + ".pkg" + key))
         triggers.append(schema + ".pkg" + key);
     }


### PR DESCRIPTION
It's unclear but this bug might be responsible for a number of mysterious failures we've seen in the past.