### PR TITLE
issue #9415, issue #16266 - make it easy to load .tar files

### DIFF
--- a/loader/loaderwindow.cpp
+++ b/loader/loaderwindow.cpp
@@ -428,7 +428,7 @@ void LoaderWindow::fileOpen()
 
   QString filename = QFileDialog::getOpenFileName(this,
                                                   tr("Open Package"), path,
-                                                  tr("Package Files (*.gz);;All Files (*.*)"));
+                                                  tr("Package Files (*.gz *.tar);;All Files (*.*)"));
 
   if (! openFile(filename))
     return;


### PR DESCRIPTION
This does not fully address issue 9415 but is as much as we're going to do. We're not going to support additional file formats unless absolutely necessary.